### PR TITLE
Parameter description misplacement

### DIFF
--- a/nanoFramework.System.Net/Sockets/NetworkStream.cs
+++ b/nanoFramework.System.Net/Sockets/NetworkStream.cs
@@ -53,9 +53,9 @@ namespace System.Net.Sockets
         //     nonblocking state.
 
         /// <summary>
-        /// Creates a new instance of the System.Net.Sockets.NetworkStream class for the specified System.Net.Sockets.Socket.
+        /// Creates a new instance of the <see cref="NetworkStream"/> class for the specified <see cref="Socket"/>.
         /// </summary>
-        /// <param name="socket">The System.Net.Sockets.Socket that the System.Net.Sockets.NetworkStream will use to send and receive data.</param>
+        /// <param name="socket">The <see cref="Socket"/> that the <see cref="NetworkStream"/> will use to send and receive data.</param>
         public NetworkStream(Socket socket)
             : this(socket, false)
         {
@@ -86,12 +86,12 @@ namespace System.Net.Sockets
         //     socket is null.
 
         /// <summary>
-        /// Initializes a new instance of the System.Net.Sockets.NetworkStream class for the specified 
-        /// System.Net.Sockets.Socket with the specified System.Net.Sockets.Socket ownership.
+        /// Initializes a new instance of the <see cref="NetworkStream"/> class for the specified 
+        /// <see cref="Socket"/> with the specified <see cref="Socket"/> ownership.
         /// </summary>
-        /// <param name="socket">The System.Net.Sockets.Socket that the System.Net.Sockets.NetworkStream will
+        /// <param name="socket">The <see cref="Socket"/> that the <see cref="NetworkStream"/> will
         /// use to send and receive data.</param>
-        /// <param name="ownsSocket">true to indicate that the System.Net.Sockets.NetworkStream will take ownership of the System.Net.Sockets.Socket; 
+        /// <param name="ownsSocket">true to indicate that the <see cref="NetworkStream"/> will take ownership of the <see cref="Socket"/>; 
         /// otherwise, false.</param>
         public NetworkStream(Socket socket, bool ownsSocket)
         {

--- a/nanoFramework.System.Net/Sockets/NetworkStream.cs
+++ b/nanoFramework.System.Net/Sockets/NetworkStream.cs
@@ -92,7 +92,7 @@ namespace System.Net.Sockets
         /// <param name="socket">The <see cref="Socket"/> that the <see cref="NetworkStream"/> will
         /// use to send and receive data.</param>
         /// <param name="ownsSocket"><see langword="true"/> to indicate that the <see cref="NetworkStream"/> will take ownership of the <see cref="Socket"/>; 
-        /// otherwise, false.</param>
+        /// otherwise, <see langword="false"/>.</param>
         public NetworkStream(Socket socket, bool ownsSocket)
         {
             if (socket == null) throw new ArgumentNullException();

--- a/nanoFramework.System.Net/Sockets/NetworkStream.cs
+++ b/nanoFramework.System.Net/Sockets/NetworkStream.cs
@@ -89,10 +89,10 @@ namespace System.Net.Sockets
         /// Initializes a new instance of the System.Net.Sockets.NetworkStream class for the specified 
         /// System.Net.Sockets.Socket with the specified System.Net.Sockets.Socket ownership.
         /// </summary>
-        /// <param name="socket">true to indicate that the System.Net.Sockets.NetworkStream will take ownership of the System.Net.Sockets.Socket; 
-        /// otherwise, false.</param>
-        /// <param name="ownsSocket">The System.Net.Sockets.Socket that the System.Net.Sockets.NetworkStream will
+        /// <param name="socket">The System.Net.Sockets.Socket that the System.Net.Sockets.NetworkStream will
         /// use to send and receive data.</param>
+        /// <param name="ownsSocket">true to indicate that the System.Net.Sockets.NetworkStream will take ownership of the System.Net.Sockets.Socket; 
+        /// otherwise, false.</param>
         public NetworkStream(Socket socket, bool ownsSocket)
         {
             if (socket == null) throw new ArgumentNullException();

--- a/nanoFramework.System.Net/Sockets/NetworkStream.cs
+++ b/nanoFramework.System.Net/Sockets/NetworkStream.cs
@@ -91,7 +91,7 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="socket">The <see cref="Socket"/> that the <see cref="NetworkStream"/> will
         /// use to send and receive data.</param>
-        /// <param name="ownsSocket">true to indicate that the <see cref="NetworkStream"/> will take ownership of the <see cref="Socket"/>; 
+        /// <param name="ownsSocket"><see langword="true"/> to indicate that the <see cref="NetworkStream"/> will take ownership of the <see cref="Socket"/>; 
         /// otherwise, false.</param>
         public NetworkStream(Socket socket, bool ownsSocket)
         {


### PR DESCRIPTION
## Description

- In `NetworkStream` constructor parameters descriptions was misplaced. Fixed it.

## Motivation and Context

- Avoid confusion.
- It's my first PR. So I highly motivated to train on this little fixes how to do PR's right.

## How Has This Been Tested?

- Checked by eyes.

## Screenshots<!-- (if appropriate): -->

## Types of changes

- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
