### PR TITLE
Fix byte constructor

### DIFF
--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -21,7 +21,7 @@ namespace System.Net
         /// This field is read-only.
         /// </summary>
         public static readonly IPAddress Any = new IPAddress(0x0000000000000000);
-        
+
         /// <summary>
         /// Provides the IP loopback address. This field is read-only.
         /// </summary>
@@ -75,13 +75,23 @@ namespace System.Net
         /// <param name="address"></param>
         public IPAddress(byte[] address)
         {
-            if (address[0] == (byte)AddressFamily.InterNetwork)
+            if (address == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            if (address.Length != IPv4AddressBytes && address.Length != IPv6AddressBytes)
+            {
+                // unsupported address family
+                throw new NotSupportedException();
+            }
+
+            if (address.Length == IPv4AddressBytes)
             {
                 _family = AddressFamily.InterNetwork;
-                // need to offset address by 4 (1st are family, 2nd are port
-                Address = ((address[3 + 4] << 24 | address[2 + 4] << 16 | address[1 + 4] << 8 | address[0 + 4]) & 0x0FFFFFFFF);
+                Address = ((address[3] << 24 | address[2] << 16 | address[1] << 8 | address[0]) & 0x0FFFFFFFF);
             }
-            else if (address[0] == (byte)AddressFamily.InterNetworkV6)
+            else
             {
                 _family = AddressFamily.InterNetworkV6;
 
@@ -89,11 +99,6 @@ namespace System.Net
                 {
                     _numbers[i] = (ushort)(address[i * 2] * 256 + address[i * 2 + 1]);
                 }
-            }
-            else
-            {
-                // unsupported address family
-                throw new NotSupportedException();
             }
         }
 
@@ -188,8 +193,8 @@ namespace System.Net
                 case AddressFamily.InterNetwork:
                     return new IPAddress(Address);
 
-                //case AddressFamily.InterNetworkV6:
-                //    return new IPAddress(m_Numbers, (uint)m_ScopeId);
+                    //case AddressFamily.InterNetworkV6:
+                    //    return new IPAddress(m_Numbers, (uint)m_ScopeId);
             }
 
             throw new NotSupportedException();


### PR DESCRIPTION
## Description

Align byte constructor with .net 

Will leave current support for IPV6 as in future it will need to be implemented fully. 

Breaking change but shouldn't be used anywhere as not compliant with .Net

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested constructor for Ipv4 and Ipv6 addresses

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
