### PR TITLE
NetworkReady event is now instanciated on constructor

### DIFF
--- a/nanoFramework.System.Net/NetworkHelper/NetworkHelper.cs
+++ b/nanoFramework.System.Net/NetworkHelper/NetworkHelper.cs
@@ -16,7 +16,7 @@ namespace nanoFramework.Networking
     public static class NetworkHelper
     {
         private static ManualResetEvent _ipAddressAvailable;
-        private static ManualResetEvent _networkReady;
+        private static ManualResetEvent _networkReady = new(false);
 
         private static bool _requiresDateTime;
         private static NetworkHelperStatus _networkHelperStatus = NetworkHelperStatus.None;
@@ -257,9 +257,6 @@ namespace nanoFramework.Networking
 
                     // setup handler
                     NetworkChange.NetworkAddressChanged += new NetworkAddressChangedEventHandler(AddressChangedCallback);
-
-                    // instantiate events
-                    _networkReady = new(false);
                 }
 
                 NetworkHelperInternal.InternalSetupHelper(nis, _workingNetworkInterface, _ipConfiguration);
@@ -276,7 +273,7 @@ namespace nanoFramework.Networking
         internal static void ResetInstance()
         {
             _ipAddressAvailable = null;
-            _networkReady = null;
+            _networkReady = new(false);
             _requiresDateTime = false;
             _networkHelperStatus = NetworkHelperStatus.None;
             _helperException = null;


### PR DESCRIPTION
## Description
- Event is now instanciated on class constructor.
- Update code accordingly.

## Motivation and Context
- Makes it possible to wait on the event before calling the setup methods.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
