### PR TITLE
Improvements in get/set socket options

### DIFF
--- a/Tests/SocketTests/SocketOptionsTests.cs
+++ b/Tests/SocketTests/SocketOptionsTests.cs
@@ -1,0 +1,72 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.TestFramework;
+using System;
+using System.Net.Sockets;
+
+namespace NFUnitTestSocketTests
+{
+    [TestClass]
+    public class SocketOptionsTests
+    {
+        [Setup]
+        public void SetupConnectToEthernetTests()
+        {
+            // Comment next line to run the tests on a real hardware
+            Assert.SkipTest("Skipping tests using nanoCLR Win32 in a pipeline");
+        }
+
+        [TestMethod]
+        public void SocketGetSocketOptions_00()
+        {
+            SocketType socketType = SocketType.Stream;
+
+            Socket testSocket = new(
+                AddressFamily.InterNetwork,
+                socketType,
+                ProtocolType.Tcp);
+
+            Assert.Throws(typeof(NotSupportedException), () =>
+            {
+                testSocket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.AddMembership);
+            }, "Getting SocketOptionName.AddMembership should have thrown an exception");
+
+            Assert.Throws(typeof(NotSupportedException), () =>
+            {
+                testSocket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DropMembership);
+            }, "Getting SocketOptionName.DropMembership should have thrown an exception");
+
+            Assert.True((SocketType)testSocket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Type) == socketType, "Getting SocketOptionName.Type returned a different type.");
+
+            testSocket?.Close();
+        }
+
+        [TestMethod]
+        public void SocketLinger()
+        {
+            SocketType socketType = SocketType.Stream;
+
+            Socket testSocket = new(
+                AddressFamily.InterNetwork,
+                socketType,
+                ProtocolType.Tcp);
+
+            // TODO
+            // connect to endpoint
+
+            // get linger option
+            //Assert.IsType(typeof(bool), testSocket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontLinger), "SocketOptionName.DontLinger should return a bool.");
+
+            // set DontLinger option
+            // read back linger option
+            // set LINGER value
+
+            // read back linger option
+
+            testSocket?.Close();
+        }
+    }
+}

--- a/Tests/SocketTests/SocketTests.nfproj
+++ b/Tests/SocketTests/SocketTests.nfproj
@@ -27,6 +27,7 @@
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\nano.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="SocketOptionsTests.cs" />
     <Compile Include="SocketPair.cs" />
     <Compile Include="SocketExceptionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
## Description
- Rework GetSocketOption to correctly return correct type with several SocketOptionName.
- GetSocketOption can now return value for SocketOptionName.DontLinger.
- Rewrote some parts of the documentation to make it clearer.
- Add some unit tests for socket options.

## Motivation and Context
- Addresses nanoFramework/Home#937.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Unit tests and network sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (work on Unit Tests, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
