### PR TITLE
Only Enable DHCP if required

### DIFF
--- a/nanoFramework.System.Net/NetworkHelper/NetworkHelperInternal.cs
+++ b/nanoFramework.System.Net/NetworkHelper/NetworkHelperInternal.cs
@@ -92,7 +92,11 @@ namespace nanoFramework.Networking
                     }
                     else
                     {
-                        networkInterface.EnableDhcp();
+                        if (!networkInterface.IsDhcpEnabled)
+                        {
+                            networkInterface.EnableDhcp();
+                        }
+
                         networkInterface.EnableAutomaticDns();
                     }
                 }


### PR DESCRIPTION
## Description

This change only enables DHCP when not already enabled

## Motivation and Context

Found that resetting DHCP during start up when DHCP was already enabled cause the getting of IP to be unreliable.
WHen testing Ethernet found the DHCP was changed at the same time as a DHCP was being handled and caused the GOT IP event to go missing which was needed to start the SNTP task.


## How Has This Been Tested?<!-- (IF APPLICABLE) -->

Tested with updated (NetworkHelper) version of Network Client sample with Ethernet on ESP32

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
