### PR TITLE
Improvements in X.509 constructors

### DIFF
--- a/nanoFramework.System.Net/X509Certificates/X509Certificate.cs
+++ b/nanoFramework.System.Net/X509Certificates/X509Certificate.cs
@@ -4,7 +4,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
-namespace System.Security.Cryptography.X509Certificates 
+namespace System.Security.Cryptography.X509Certificates
 {
     using System;
     using System.Runtime.CompilerServices;
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.X509Certificates
         /// ASN.1 DER is the only certificate format supported by this class. 
         /// </remarks>
         public X509Certificate(byte[] certificate)
-            : this(certificate, "")
+            : this(certificate, null)
         {
         }
 
@@ -76,7 +76,7 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Certificate(byte[] certificate, string password)
         {
             _certificate = certificate;
-            _password    = password;
+            _password = password;
 
             ParseCertificate(certificate, password, ref _issuer, ref _subject, ref _effectiveDate, ref _expirationDate);
         }
@@ -100,8 +100,6 @@ namespace System.Security.Cryptography.X509Certificates
             _certificate = new byte[tempCertificate.Length + 1];
             Array.Copy(tempCertificate, _certificate, tempCertificate.Length);
             _certificate[_certificate.Length - 1] = 0;
-
-            _password = "";
 
             ParseCertificate(_certificate, _password, ref _issuer, ref _subject, ref _effectiveDate, ref _expirationDate);
         }

--- a/nanoFramework.System.Net/X509Certificates/X509Certificate2.cs
+++ b/nanoFramework.System.Net/X509Certificates/X509Certificate2.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography.X509Certificates
     public class X509Certificate2 : X509Certificate
     {
 #pragma warning disable S3459 // Unassigned members should be removed
-        // these fields are required and set in native code
+        // field required to be accessible by native code
         private readonly byte[] _privateKey;
 #pragma warning restore S3459 // Unassigned members should be removed
 
@@ -25,6 +25,7 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Certificate2()
             : base()
         {
+
         }
 
         /// <summary>
@@ -75,14 +76,19 @@ namespace System.Security.Cryptography.X509Certificates
         /// <summary>
         /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 public certificate, the private key and a password used to access the certificate.
         /// </summary>
-        /// <param name="certificate">A string containing a X.509 certificate.</param>
+        /// <param name="rawData">A string containing a X.509 certificate.</param>
         /// <param name="key">A string containing a PEM private key.</param>
-        /// <param name="password">The password required to access the X.509 certificate data.</param>
+        /// <param name="password">The password required to access the X.509 certificate data. Set to <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted and do not require a password.</param>
         /// <remarks>
         /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
         /// </remarks>
-        public X509Certificate2(string certificate, string key, string password)
-            : base(certificate, password)
+        public X509Certificate2(
+            string rawData,
+            string key,
+            string password)
+            : base(
+                  rawData,
+                  password)
         {
             var tempKey = Encoding.UTF8.GetBytes(key);
 
@@ -104,12 +110,17 @@ namespace System.Security.Cryptography.X509Certificates
         /// </summary>
         /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
         /// <param name="key">A string containing a PEM private key.</param>
-        /// <param name="password">The password required to access the X.509 certificate data.</param>
+        /// <param name="password">The password required to access the X.509 certificate data. Set to <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted and do not require a password.</param>
         /// <remarks>
         /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
         /// </remarks>
-        public X509Certificate2(byte[] rawData, string key, string password)
-            : base(rawData, password)
+        public X509Certificate2(
+            byte[] rawData,
+            string key,
+            string password)
+            : base(
+                  rawData,
+                  password)
         {
             var tempKey = Encoding.UTF8.GetBytes(key);
 
@@ -131,12 +142,17 @@ namespace System.Security.Cryptography.X509Certificates
         /// </summary>
         /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
         /// <param name="key">A byte array containing a PEM private key.</param>
-        /// <param name="password">The password required to access the X.509 certificate data.</param>
+        /// <param name="password">The password required to access the X.509 certificate data. <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted.</param>
         /// <remarks>
         /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
         /// </remarks>
-        public X509Certificate2(byte[] rawData, byte[] key, string password)
-            : base(rawData, password)
+        public X509Certificate2(
+            byte[] rawData,
+            byte[] key,
+            string password)
+            : base(
+                  rawData,
+                  password)
         {
             _privateKey = key;
 


### PR DESCRIPTION
## Description
- Add default parameter value for password (null). 
- Improve documentation comments.

## Motivation and Context
- Now it's possible to create a certificate with just the certificate data and an unencrypted private key.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
