### PR TITLE
Remove password parameter from X.509 constructors

### DIFF
--- a/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -12,7 +11,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.4.1")]
+[assembly: AssemblyNativeVersion("100.1.5.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/nanoFramework.System.Net/X509Certificates/X509Certificate.cs
+++ b/nanoFramework.System.Net/X509Certificates/X509Certificate.cs
@@ -14,12 +14,11 @@ namespace System.Security.Cryptography.X509Certificates
     /// Provides methods that help you use X.509 v.3 certificates.
     /// </summary>
     /// <remarks>
-    /// ASN.1 DER is the only certificate format supported by this class.
+    /// Supported formats: DER and PEM.
     /// </remarks>
     public class X509Certificate
     {
         private readonly byte[] _certificate;
-        private readonly string _password;
 
         /// <summary>
         /// Contains the certificate issuer.
@@ -58,27 +57,18 @@ namespace System.Security.Cryptography.X509Certificates
         /// </summary>
         /// <param name="certificate">A byte array containing data from an X.509 certificate.</param>
         /// <remarks>
-        /// ASN.1 DER is the only certificate format supported by this class. 
+        /// DER and PEM encoding are the supported formats. 
         /// </remarks>
         public X509Certificate(byte[] certificate)
-            : this(certificate, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="X509Certificate"/> class using a byte array and a password.
-        /// </summary>
-        /// <param name="certificate">A byte array containing data from an X.509 certificate.</param>
-        /// <param name="password">The password required to access the X.509 certificate data.</param>
-        /// <remarks>
-        /// ASN.1 DER is the only certificate format supported by this class. 
-        /// </remarks>
-        public X509Certificate(byte[] certificate, string password)
         {
             _certificate = certificate;
-            _password = password;
 
-            ParseCertificate(certificate, password, ref _issuer, ref _subject, ref _effectiveDate, ref _expirationDate);
+            ParseCertificate(
+                certificate,
+                ref _issuer,
+                ref _subject,
+                ref _effectiveDate,
+                ref _expirationDate);
         }
 
         /// <summary>
@@ -86,8 +76,8 @@ namespace System.Security.Cryptography.X509Certificates
         /// </summary>
         /// <param name="certificate">A string containing a X.509 certificate.</param>
         /// <remarks>
-        /// ASN.1 DER is the only certificate format supported by this class. 
-        /// This methods is exclusive of nanoFramework. The equivalent .NET constructor accepts a file name as the parameter.
+        /// Supported formats: DER and PEM.
+        /// This methods is exclusive of .NET nanoFramework. The equivalent .NET constructor accepts a file name as the parameter.
         /// </remarks>
         public X509Certificate(string certificate)
         {
@@ -101,33 +91,12 @@ namespace System.Security.Cryptography.X509Certificates
             Array.Copy(tempCertificate, _certificate, tempCertificate.Length);
             _certificate[_certificate.Length - 1] = 0;
 
-            ParseCertificate(_certificate, _password, ref _issuer, ref _subject, ref _effectiveDate, ref _expirationDate);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="X509Certificate"/> class defined from a string with the content of an X.509v3 certificate.
-        /// </summary>
-        /// <param name="certificate">A string containing a X.509 certificate.</param>
-        /// <param name="password">The password required to access the X.509 certificate data.</param>
-        /// <remarks>
-        /// ASN.1 DER is the only certificate format supported by this class. 
-        /// This methods is exclusive of nanoFramework. The equivalent .NET constructor accepts a file name as the parameter.
-        /// </remarks>
-        public X509Certificate(string certificate, string password)
-        {
-            _password = password;
-
-            var tempCertificate = Encoding.UTF8.GetBytes(certificate);
-
-            //////////////////////////////////////////////
-            // because this is parsing from a string    //
-            // we need to keep the terminator           //
-            //////////////////////////////////////////////
-            _certificate = new byte[tempCertificate.Length + 1];
-            Array.Copy(tempCertificate, _certificate, tempCertificate.Length);
-            _certificate[_certificate.Length - 1] = 0;
-
-            ParseCertificate(_certificate, _password, ref _issuer, ref _subject, ref _effectiveDate, ref _expirationDate);
+            ParseCertificate(
+                _certificate,
+                ref _issuer,
+                ref _subject,
+                ref _effectiveDate,
+                ref _expirationDate);
         }
 
         /// <summary>
@@ -186,7 +155,12 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern void ParseCertificate(byte[] cert, string password, ref string issuer, ref string subject, ref DateTime effectiveDate, ref DateTime expirationDate);
+        internal static extern void ParseCertificate(
+            byte[] cert,
+            ref string issuer,
+            ref string subject,
+            ref DateTime effectiveDate,
+            ref DateTime expirationDate);
     }
 }
 

--- a/nanoFramework.System.Net/X509Certificates/X509Certificate2.cs
+++ b/nanoFramework.System.Net/X509Certificates/X509Certificate2.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography.X509Certificates
 #pragma warning disable S3459 // Unassigned members should be removed
         // field required to be accessible by native code
         private readonly byte[] _privateKey;
+        private readonly string _password;
 #pragma warning restore S3459 // Unassigned members should be removed
 
         /// <summary>
@@ -25,7 +26,6 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Certificate2()
             : base()
         {
-
         }
 
         /// <summary>
@@ -38,22 +38,11 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a byte array and a password.
-        /// </summary>
-        /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
-        /// <param name="password">The password required to access the X.509 certificate data.</param>
-        public X509Certificate2(byte[] rawData, string password)
-            : base(rawData, password)
-        {
-        }
-
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 certificate.
         /// </summary>
         /// <param name="certificate">A string containing a X.509 certificate.</param>
         /// <remarks>
-        /// This methods is exclusive of nanoFramework. The equivalent .NET constructor accepts a file name as the parameter.
+        /// This methods is exclusive of .NET nanoFramework. The equivalent .NET constructor accepts a file name as the parameter.
         /// </remarks>
         public X509Certificate2(string certificate)
             : base(certificate)
@@ -61,34 +50,19 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 certificate and a password used to access the certificate.
-        /// </summary>
-        /// <param name="certificate">A string containing a X.509 certificate.</param>
-        /// <param name="password">The password required to access the X.509 certificate data.</param>
-        /// <remarks>
-        /// This methods is exclusive of nanoFramework. The equivalent .NET constructor accepts a file name as the parameter.
-        /// </remarks>
-        public X509Certificate2(string certificate, string password)
-            : base(certificate, password)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 public certificate, the private key and a password used to access the certificate.
+        /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 public certificate, the private key and a password used to access the private key.
         /// </summary>
         /// <param name="rawData">A string containing a X.509 certificate.</param>
-        /// <param name="key">A string containing a PEM private key.</param>
-        /// <param name="password">The password required to access the X.509 certificate data. Set to <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted and do not require a password.</param>
+        /// <param name="key">A string containing a private key in PEM or DER format.</param>
+        /// <param name="password">The password required to decrypt the private key. Set to <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted and do not require a password.</param>
         /// <remarks>
-        /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
+        /// This methods is exclusive of .NET nanoFramework. There is no equivalent in .NET framework.
         /// </remarks>
         public X509Certificate2(
             string rawData,
             string key,
             string password)
-            : base(
-                  rawData,
-                  password)
+            : base(rawData)
         {
             var tempKey = Encoding.UTF8.GetBytes(key);
 
@@ -101,26 +75,27 @@ namespace System.Security.Cryptography.X509Certificates
             keyBuffer[keyBuffer.Length - 1] = 0;
 
             _privateKey = keyBuffer;
+            _password = password;
 
-            DecodePrivateKeyNative(keyBuffer, password);
+            DecodePrivateKeyNative(
+                keyBuffer,
+                password);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="X509Certificate2"/> class using a string with the content of an X.509 public certificate, the private key and a password used to access the certificate.
         /// </summary>
         /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
-        /// <param name="key">A string containing a PEM private key.</param>
-        /// <param name="password">The password required to access the X.509 certificate data. Set to <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted and do not require a password.</param>
+        /// <param name="key">A string containing a private key in PEM or DER format.</param>
+        /// <param name="password">The password required to decrypt the private key. Set to <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted and do not require a password.</param>
         /// <remarks>
-        /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
+        /// This methods is exclusive of .NET nanoFramework. There is no equivalent in .NET framework.
         /// </remarks>
         public X509Certificate2(
             byte[] rawData,
             string key,
             string password)
-            : base(
-                  rawData,
-                  password)
+            : base(rawData)
         {
             var tempKey = Encoding.UTF8.GetBytes(key);
 
@@ -133,8 +108,11 @@ namespace System.Security.Cryptography.X509Certificates
             keyBuffer[keyBuffer.Length - 1] = 0;
 
             _privateKey = keyBuffer;
+            _password = password;
 
-            DecodePrivateKeyNative(keyBuffer, password);
+            DecodePrivateKeyNative(
+                keyBuffer,
+                password);
         }
 
         /// <summary>
@@ -142,7 +120,7 @@ namespace System.Security.Cryptography.X509Certificates
         /// </summary>
         /// <param name="rawData">A byte array containing data from an X.509 certificate.</param>
         /// <param name="key">A byte array containing a PEM private key.</param>
-        /// <param name="password">The password required to access the X.509 certificate data. <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted.</param>
+        /// <param name="password">The password required to decrypt the private key. <see langword="null"/> if the <paramref name="rawData"/> or <paramref name="key"/> are not encrypted.</param>
         /// <remarks>
         /// This methods is exclusive of nanoFramework. There is no equivalent in .NET framework.
         /// </remarks>
@@ -150,17 +128,18 @@ namespace System.Security.Cryptography.X509Certificates
             byte[] rawData,
             byte[] key,
             string password)
-            : base(
-                  rawData,
-                  password)
+            : base(rawData)
         {
             _privateKey = key;
+            _password = password;
 
-            DecodePrivateKeyNative(key, password);
+            DecodePrivateKeyNative(
+                key,
+                password);
         }
 
         /// <summary>
-        /// Gets a value that indicates whether an X509Certificate2 object contains a private key.
+        /// Gets a value that indicates whether an <see cref="X509Certificate2"/> object contains a private key.
         /// </summary>
         /// <value><see langword="true"/> if the <see cref="X509Certificate2"/> object contains a private key; otherwise, <see langword="false"/>.</value>
         public bool HasPrivateKey
@@ -172,19 +151,19 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Gets the private key, null if no private key
+        /// Gets the private key, null if there isn't a private key.
         /// </summary>
         /// <remarks>This will give you access directly to the raw decoded byte array of the private key</remarks>
         public byte[] PrivateKey => _privateKey;
 
         /// <summary>
-        /// Gets the public key
+        /// Gets the public key.
         /// </summary>
-        /// <remarks>This will give you access directly to the raw decoded byte array of the public key</remarks>
+        /// <remarks>This will give you access directly to the raw decoded byte array of the public key.</remarks>
         public byte[] PublicKey => RawData;
 
         /// <summary>
-        /// Gets the date in local time after which a certificate is no longer valid.
+        /// Gets the date (in UTC time) after which a certificate is no longer valid.
         /// </summary>
         /// <value>A <see cref="DateTime"/> object that represents the expiration date for the certificate.</value>
         public DateTime NotAfter
@@ -196,7 +175,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Gets the date in local time on which a certificate becomes valid.
+        /// Gets the date (in UTC time) on which a certificate becomes valid.
         /// </summary>
         /// <value>A <see cref="DateTime"/> object that represents the effective date of the certificate.</value>
         public DateTime NotBefore
@@ -220,6 +199,8 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern void DecodePrivateKeyNative(byte[] keyBuffer, string password);
+        internal static extern void DecodePrivateKeyNative(
+            byte[] keyBuffer,
+            string password);
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- Remove password parameter from X.509 constructors.
- Update code accordingly.
- Update comments and improve where needed.
- Bump AssemblyNativeVersion to 100.1.5.0
- Bump version to 1.9.0.

## Motivation and Context
- MbedTLS is not able to decode X.509 certs with password. Only private keys. Same happens with Azure Netx Duo (our other secured network layer). So it doesn't make sense to keep offering a feature that we can't support. 
- Despite being a breaking change (from the API perspective) it's not anticipated to cause any major hiccups in existing deployments as it is working as it is now (anyone trying to use it would have already complained about it by now).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- TLS samples.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
