### PR TITLE
WirelessAPConfiguration.MaxConnections is now validated

### DIFF
--- a/nanoFramework.System.Net/NetworkInformation/WirelessAPConfiguration.cs
+++ b/nanoFramework.System.Net/NetworkInformation/WirelessAPConfiguration.cs
@@ -148,6 +148,14 @@ namespace System.Net.NetworkInformation
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one 
             }
 
+            // At least one MaxConnection is required
+            if (_apMaxConnections < 1)
+            {
+#pragma warning disable S3928 // OK to not include a meaningful message
+                throw new ArgumentOutOfRangeException();
+#pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one 
+            }
+
             // If not using an open Auth then check password length
             if ( (Authentication != AuthenticationType.Open && Authentication != AuthenticationType.None)  &&
                  ( (_apPassword.Length <  MinApPasswordLength) || (_apPassword.Length >= MaxApPasswordLength) ) )

--- a/nanoFramework.System.Net/NetworkInformation/WirelessAPConfiguration.cs
+++ b/nanoFramework.System.Net/NetworkInformation/WirelessAPConfiguration.cs
@@ -121,12 +121,12 @@ namespace System.Net.NetworkInformation
         /// <remarks>
         /// Checks the length of SSID is 32 or less.
         /// Password length is between 8 and 64 if not an open Authentication.
-        /// Max connections is greater than zero
+        /// Max connections has to be greater than zero.
         /// </remarks>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="MaxConnections"/> is less than one</exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="Password"/> is less than 8 character or more than 64 characters and not open <see cref="Authentication"/></exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/></exception>
-        /// <exception cref="ArgumentNullException">Thrown if <see cref="Ssid"/> is null</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="MaxConnections"/> is less than one.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Password"/> is less than 8 character or more than 64 characters and not open <see cref="Authentication"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/><./exception>
+        /// <exception cref="ArgumentNullException">If <see cref="Ssid"/> is <see langword="null"/>.</exception>
         public void SaveConfiguration()
         {
             // Before we update validate whether settings conform to right characteristics.
@@ -138,10 +138,10 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Validates the wireless Soft AP configuration information 
         /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="MaxConnections"/> is less than one</exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="Password"/> is less than 8 character or more than 64 characters and not open <see cref="Authentication"/></exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/></exception>
-        /// <exception cref="ArgumentNullException">Thrown if <see cref="Ssid"/> is null</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="MaxConnections"/> is less than one.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Password"/> is less than 8 character or more than 64 characters and not open <see cref="Authentication"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/><./exception>
+        /// <exception cref="ArgumentNullException">If <see cref="Ssid"/> is <see langword="null"/>.</exception>
         private void ValidateConfiguration()
         {
             // SSID can't be null

--- a/nanoFramework.System.Net/NetworkInformation/WirelessAPConfiguration.cs
+++ b/nanoFramework.System.Net/NetworkInformation/WirelessAPConfiguration.cs
@@ -121,7 +121,12 @@ namespace System.Net.NetworkInformation
         /// <remarks>
         /// Checks the length of SSID is 32 or less.
         /// Password length is between 8 and 64 if not an open Authentication.
+        /// Max connections is greater than zero
         /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="MaxConnections"/> is less than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="Password"/> is less than 8 character or more than 64 characters and not open <see cref="Authentication"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/></exception>
+        /// <exception cref="ArgumentNullException">Thrown if <see cref="Ssid"/> is null</exception>
         public void SaveConfiguration()
         {
             // Before we update validate whether settings conform to right characteristics.
@@ -130,6 +135,13 @@ namespace System.Net.NetworkInformation
             UpdateConfiguration();
         }
 
+        /// <summary>
+        /// Validates the wireless Soft AP configuration information 
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="MaxConnections"/> is less than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="Password"/> is less than 8 character or more than 64 characters and not open <see cref="Authentication"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/></exception>
+        /// <exception cref="ArgumentNullException">Thrown if <see cref="Ssid"/> is null</exception>
         private void ValidateConfiguration()
         {
             // SSID can't be null


### PR DESCRIPTION
## Description
Validating WirelessAPConfiguration.MaxConnections >= 1

## Motivation and Context
This solves the problem of starting the access point with no connections available (and possibly freezing the device)

- Fixes nanoFramework/Home#1380

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
ChatGPT generated the code ;)

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
