### PR TITLE
Update sockets to support IPV6

### DIFF
--- a/nanoFramework.System.Net/DNS.cs
+++ b/nanoFramework.System.Net/DNS.cs
@@ -41,8 +41,14 @@ namespace System.Net
                 if (family == AddressFamily.InterNetwork)
                 {
                     uint ipAddr = (uint)((address[7] << 24) | (address[6] << 16) | (address[5] << 8) | (address[4]));
-
                     ipAddresses[i] = new IPAddress(ipAddr);
+                }
+                else if (family == AddressFamily.InterNetworkV6)
+                {
+                    byte[] ipv6addr = new byte[16];
+                    Array.Copy(address, 4, ipv6addr, 0, 16);
+                    
+                    ipAddresses[i] = new IPAddress(ipv6addr);
                 }
                 else
                 {

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -16,6 +16,11 @@ namespace System.Net
     [Serializable]
     public class IPAddress
     {
+        internal const int IPv4AddressBytes = 4;
+        internal const int IPv6AddressBytes = 16;
+
+        internal const int NumberOfLabels = IPv6AddressBytes / 2;
+
         /// <summary>
         /// Provides an IP address that indicates that the server must listen for client activity on all network interfaces. This field is read-only.
         /// </summary>
@@ -28,16 +33,25 @@ namespace System.Net
 
         internal readonly long Address;
 
+        /// <summary>
+        /// The Bind(EndPoint) method uses the IPv6Any field to indicate that a Socket must listen for client activity on all network interfaces.
+        /// </summary>
+        public static readonly IPAddress IPv6Any = new IPAddress(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, 0);
+
+        /// <summary>
+        /// Provides the IP loopback address. This property is read-only.
+        /// </summary>
+        public static readonly IPAddress IPv6Loopback = new IPAddress(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, 0);
+        
+
         [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
         private readonly AddressFamily _family = AddressFamily.InterNetwork;
 
         [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
         private readonly ushort[] _numbers = new ushort[NumberOfLabels];
 
-        internal const int IPv4AddressBytes = 4;
-        internal const int IPv6AddressBytes = 16;
-
-        internal const int NumberOfLabels = IPv6AddressBytes / 2;
+        [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
+        private long _scopeid = 0;
 
         /// <summary>
         /// Gets the address family of the IP address.
@@ -81,7 +95,7 @@ namespace System.Net
         /// <summary>
         /// Initializes a new instance of the <see cref="IPAddress"/> class with the address specified as a Byte array.
         /// </summary>
-        /// <param name="address"></param>
+        /// <param name="address">The byte array value of the IP address.</param>
         /// <exception cref="ArgumentNullException"><paramref name="address"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="address"/> contains a bad IP address.</exception>
         /// <remarks>
@@ -123,6 +137,40 @@ namespace System.Net
         }
 
         /// <summary>
+        /// Initializes a new instance of a IPV6 <see cref="IPAddress"/> class with the address specified as a Byte array.
+        /// </summary>
+        /// <param name="address">The byte array value of the IP address.</param>
+        /// <param name="scopeid">The long value of the scope identifier.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="address"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="address"/> contains a bad IP address.</exception>
+        /// <remarks>
+        /// The IPAddress is created with the <see cref="Address"/> property set to <paramref name="address"/>.
+        /// If the length of <paramref name="address"/> is 4, <see cref="IPAddress"/>(Byte[]) constructs an IPv4 address; otherwise, an IPv6 address with a scope of 0 is constructed.
+        /// The <see cref="Byte"/> array is assumed to be in network byte order with the most significant byte first in index position 0.
+        /// </remarks>
+        public IPAddress(byte[] address, long scopeid) : this(address) 
+        {
+            if (address.Length == IPv6AddressBytes)
+            {
+                _scopeid = scopeid;
+            }
+            else
+            {
+                // Not IPV6 address
+#pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one 
+                throw new ArgumentException();
+#pragma warning restore S3928 // OK to throw this here
+            }
+        }
+
+        private IPAddress(ushort[] address, uint scopeid)
+        {
+            _family = AddressFamily.InterNetworkV6;
+            _numbers = address;
+            _scopeid = scopeid;
+        }
+
+        /// <summary>
         /// Compares two IP addresses.
         /// </summary>
         /// <param name="obj">An <see cref="IPAddress"/> instance to compare to the current instance.</param>
@@ -133,7 +181,31 @@ namespace System.Net
 
             if (obj == null) return false;
 
-            return this.Address == addr.Address;
+            // Compare family before address
+            if (_family != addr.AddressFamily)
+            {
+                return false;
+            }
+
+            if (_family == AddressFamily.InterNetworkV6)
+            {
+                // For IPv6 addresses, compare the full 128bit address
+                for (int i = 0; i < NumberOfLabels; i++)
+                {
+                    if (addr._numbers[i] != this._numbers[i])
+                        return false;
+                }
+
+                // Also scope must match
+                if (addr._scopeid == this._scopeid)
+                    return true;
+
+                return false;
+            }
+            else
+            {
+                return this.Address == addr.Address;
+            }
         }
 
         /// <summary>
@@ -142,13 +214,30 @@ namespace System.Net
         /// <returns>A Byte array.</returns>
         public byte[] GetAddressBytes()
         {
-            return new byte[]
+            byte[] bytes;
+
+            if (_family == AddressFamily.InterNetworkV6)
             {
-                (byte)(Address),
-                (byte)(Address >> 8),
-                (byte)(Address >> 16),
-                (byte)(Address >> 24)
-            };
+                bytes = new byte[NumberOfLabels * 2];
+
+                int j = 0;
+                for (int i = 0; i < NumberOfLabels; i++)
+                {
+                    bytes[j++] = (byte)((this._numbers[i] >> 8) & 0xFF);
+                    bytes[j++] = (byte)((this._numbers[i]) & 0xFF);
+                }
+                return bytes;
+            }
+            else
+            {
+                return new byte[]
+                {
+                    (byte)(Address),
+                    (byte)(Address >> 8),
+                    (byte)(Address >> 16),
+                    (byte)(Address >> 24)
+                };
+            }
         }
 
         /// <summary>
@@ -159,7 +248,40 @@ namespace System.Net
         /// </returns>
         public static IPAddress Parse(string ipString)
         {
-            return new IPAddress(NetworkInterface.IPAddressFromString(ipString));
+            // Check for IPV6 string and use separate parse method 
+            if (ipString.IndexOf(':') != -1)
+            {
+                return new IPAddress(NetworkInterface.IPV6AddressFromString(ipString), 0);
+            }
+
+            return new IPAddress(NetworkInterface.IPV4AddressFromString(ipString));
+        }
+
+        /// <summary>
+        /// Get or Set IPV6 scope identifier.
+        /// </summary>
+        public long ScopeId
+        {
+            get 
+            {
+                // Not valid for IPv4 addresses
+                if (_family == AddressFamily.InterNetwork)
+                {
+                    throw new SocketException(SocketError.OperationNotSupported);
+                }
+
+                return _scopeid; 
+            }
+            set 
+            {
+                // Not valid for IPv4 addresses
+                if (_family == AddressFamily.InterNetwork)
+                {
+                    throw new SocketException(SocketError.OperationNotSupported);
+                }
+
+                _scopeid = value; 
+            }
         }
 
         /// <summary>
@@ -172,6 +294,11 @@ namespace System.Net
         /// </remarks>
         public override string ToString()
         {
+            if (_family == AddressFamily.InterNetworkV6)
+            {
+                return IPv6ToString(_numbers);
+            }
+
             return IPv4ToString((uint)Address);
         }
 
@@ -229,11 +356,91 @@ namespace System.Net
                 case AddressFamily.InterNetwork:
                     return new IPAddress(Address);
 
-                    //case AddressFamily.InterNetworkV6:
-                    //    return new IPAddress(m_Numbers, (uint)m_ScopeId);
+                case AddressFamily.InterNetworkV6:
+                    return new IPAddress(_numbers, (uint)_scopeid);
             }
 
             throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Gets whether the IP address is an IPv4-mapped IPv6 address.
+        /// </summary>
+        /// <returns>
+        /// true if the IP address is an IPv4-mapped IPv6 address; otherwise, false.
+        /// </returns>
+        public bool IsIPv4MappedToIPv6
+        {
+            get
+            {
+                if (AddressFamily != AddressFamily.InterNetworkV6)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < 5; i++)
+                {
+                    if (_numbers[i] != 0)
+                    {
+                        return false;
+                    }
+                }
+
+                return (_numbers[5] == 0xFFFF);
+            }
+        }
+
+        /// <summary>
+        /// Maps the <see cref="IPAddress"/> object to an IPv6 address.
+        /// </summary>
+        /// <remarks>
+        /// Dual-stack sockets always require IPv6 addresses. The ability to interact with an IPv4 address 
+        /// requires the use of the IPv4-mapped IPv6 address format. Any IPv4 addresses must be represented 
+        /// in the IPv4-mapped IPv6 address format which enables an IPv6 only application to communicate 
+        /// with an IPv4 node.
+        /// For example.  IPv4 192.168.1.4 maps as IPV6 ::FFFF:192.168.1.4
+        /// </remarks>
+        /// <returns>
+        /// Returns <see cref="IPAddress"/>. An IPV6 address.
+        /// </returns>
+        public IPAddress MapToIPv6()
+        {
+            if (AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                return this;
+            }
+
+            ushort[] labels = new ushort[IPAddress.NumberOfLabels];
+            labels[5] = 0xFFFF;
+            labels[6] = (ushort)(((Address & 0x0000FF00) >> 8) | ((Address & 0x000000FF) << 8));
+            labels[7] = (ushort)(((Address & 0xFF000000) >> 24) | ((Address & 0x00FF0000) >> 8));
+
+            return new IPAddress(labels, 0);
+        }
+
+        /// <summary>
+        /// Maps the <see cref="IPAddress"/> object to an IPv4 address.
+        /// </summary>
+        /// <remarks> 
+        /// Dual-stack sockets always require IPv6 addresses. The ability to interact with an IPv4 
+        /// address requires the use of the IPv4-mapped IPv6 address format. 
+        /// </remarks>
+        /// <returns>
+        /// Returns <see cref="IPAddress"/>. An IPV4 address.
+        /// </returns>
+        public IPAddress MapToIPv4()
+        {
+            if (AddressFamily == AddressFamily.InterNetwork)
+            {
+                return this;
+            }
+
+            long address =  ((((uint)_numbers[6] & 0x0000FF00u) >> 8) | 
+                            (((uint)_numbers[6] & 0x000000FFu) << 8)) |
+                            (((((uint)_numbers[7] & 0x0000FF00u) >> 8) | 
+                            (((uint)_numbers[7] & 0x000000FFu) << 8)) << 16);
+
+            return new IPAddress(address);
         }
 
         #region native methods
@@ -241,6 +448,8 @@ namespace System.Net
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern string IPv4ToString(uint ipv4Address);
 
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern string IPv6ToString(ushort[] ipv6Address);
         #endregion
     }
 }

--- a/nanoFramework.System.Net/NetworkInformation/NetworkInterface.cs
+++ b/nanoFramework.System.Net/NetworkInformation/NetworkInterface.cs
@@ -126,9 +126,9 @@ namespace System.Net.NetworkInformation
         {
             try
             {
-                _ipv4Address = (uint)IPAddressFromString(ipv4Address);
-                _ipv4NetMask = (uint)IPAddressFromString(ipv4SubnetMask);
-                _ipv4GatewayAddress = (uint)IPAddressFromString(ipv4GatewayAddress);
+                _ipv4Address = (uint)IPV4AddressFromString(ipv4Address);
+                _ipv4NetMask = (uint)IPV4AddressFromString(ipv4SubnetMask);
+                _ipv4GatewayAddress = (uint)IPV4AddressFromString(ipv4GatewayAddress);
                 _startupAddressMode = AddressMode.Static;
 
                 UpdateConfiguration((int)UpdateOperation.Dhcp);
@@ -153,9 +153,9 @@ namespace System.Net.NetworkInformation
 
                 // FIXME
                 // need to test this
-                //_ipv6Address = IPAddressFromString(ipv6Address);
-                //_ipv6NetMask = IPAddressFromString(ipv6subnetMask);
-                //_ipv6GatewayAddress = IPAddressFromString(ipv6gatewayAddress);
+                //_ipv6Address = IPV4AddressFromString(ipv6Address);
+                //_ipv6NetMask = IPV4AddressFromString(ipv6subnetMask);
+                //_ipv6GatewayAddress = IPV4AddressFromString(ipv6gatewayAddress);
 
                 //_startupAddressMode = AddressMode.Static;
 
@@ -182,15 +182,15 @@ namespace System.Net.NetworkInformation
             {
                 throw new NotImplementedException();
 
-                _ipv4Address = (uint)IPAddressFromString(ipv4Address);
-                _ipv4NetMask = (uint)IPAddressFromString(ipv4subnetMask);
-                _ipv4GatewayAddress = (uint)IPAddressFromString(ipv4gatewayAddress);
+                _ipv4Address = (uint)IPV4AddressFromString(ipv4Address);
+                _ipv4NetMask = (uint)IPV4AddressFromString(ipv4subnetMask);
+                _ipv4GatewayAddress = (uint)IPV4AddressFromString(ipv4gatewayAddress);
 
                 // FIXME
                 // need to test this
-                //_ipv6Address = IPAddressFromString(ipv6Address);
-                //_ipv6NetMask = IPAddressFromString(ipv6subnetMask);
-                //_ipv6GatewayAddress = IPAddressFromString(ipv6gatewayAddress);
+                //_ipv6Address = IPV4AddressFromString(ipv6Address);
+                //_ipv6NetMask = IPV4AddressFromString(ipv6subnetMask);
+                //_ipv6GatewayAddress = IPV4AddressFromString(ipv6gatewayAddress);
 
                 _startupAddressMode = AddressMode.Static;
 
@@ -234,7 +234,7 @@ namespace System.Net.NetworkInformation
             int iAddress = 0;
             for (int i = 0; i < dnsAddresses.Length; i++)
             {
-                uint address = (uint)IPAddressFromString(dnsAddresses[i]);
+                uint address = (uint)IPV4AddressFromString(dnsAddresses[i]);
 
                 addresses[iAddress] = address;
 
@@ -281,7 +281,7 @@ namespace System.Net.NetworkInformation
             //int iAddress = 0;
             //for (int i = 0; i < dnsAddresses.Length; i++)
             //{
-            //    uint address = IPAddressFromString(dnsAddresses[i]);
+            //    uint address = IPV4AddressFromString(dnsAddresses[i]);
 
             //    addresses[iAddress] = address;
 
@@ -482,8 +482,10 @@ namespace System.Net.NetworkInformation
         private extern void UpdateConfiguration(int updateType);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern long IPAddressFromString(string ipAddress);
+        internal static extern long IPV4AddressFromString(string ipAddress);
 
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern ushort[] IPV6AddressFromString(string ipAddress);
         #endregion
     }
 }

--- a/nanoFramework.System.Net/NetworkInformation/WirelessAPConfiguration.cs
+++ b/nanoFramework.System.Net/NetworkInformation/WirelessAPConfiguration.cs
@@ -125,7 +125,7 @@ namespace System.Net.NetworkInformation
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">If <see cref="MaxConnections"/> is less than one.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If <see cref="Password"/> is less than 8 character or more than 64 characters and not open <see cref="Authentication"/>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/><./exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/></exception>
         /// <exception cref="ArgumentNullException">If <see cref="Ssid"/> is <see langword="null"/>.</exception>
         public void SaveConfiguration()
         {
@@ -140,7 +140,7 @@ namespace System.Net.NetworkInformation
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">If <see cref="MaxConnections"/> is less than one.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If <see cref="Password"/> is less than 8 character or more than 64 characters and not open <see cref="Authentication"/>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/><./exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="Ssid"/> is longer than <see cref="MaxApSsidLength"/></exception>
         /// <exception cref="ArgumentNullException">If <see cref="Ssid"/> is <see langword="null"/>.</exception>
         private void ValidateConfiguration()
         {

--- a/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.5.0")]
+[assembly: AssemblyNativeVersion("100.2.0.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/nanoFramework.System.Net/SocketAddress.cs
+++ b/nanoFramework.System.Net/SocketAddress.cs
@@ -48,29 +48,29 @@ namespace System.Net
             m_Buffer[2] = 0;
             m_Buffer[3] = 0;
 
-            //if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
-            //{
-            //    // No handling for Flow Information
-            //    m_Buffer[4] = 0;
-            //    m_Buffer[5] = 0;
-            //    m_Buffer[6] = 0;
-            //    m_Buffer[7] = 0;
+            if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                // No handling for Flow Information
+                m_Buffer[4] = 0;
+                m_Buffer[5] = 0;
+                m_Buffer[6] = 0;
+                m_Buffer[7] = 0;
 
-            //    // Scope serialization
-            //    long scope = ipAddress.ScopeId;
-            //    m_Buffer[24] = (byte)scope;
-            //    m_Buffer[25] = (byte)(scope >> 8);
-            //    m_Buffer[26] = (byte)(scope >> 16);
-            //    m_Buffer[27] = (byte)(scope >> 24);
+                // Scope serialization
+                long scope = ipAddress.ScopeId;
+                m_Buffer[24] = (byte)scope;
+                m_Buffer[25] = (byte)(scope >> 8);
+                m_Buffer[26] = (byte)(scope >> 16);
+                m_Buffer[27] = (byte)(scope >> 24);
 
-            //    // Address serialization
-            //    byte[] addressBytes = ipAddress.GetAddressBytes();
-            //    for (int i = 0; i < addressBytes.Length; i++)
-            //    {
-            //        m_Buffer[8 + i] = addressBytes[i];
-            //    }
-            //}
-            //else
+                // Address serialization
+                byte[] addressBytes = ipAddress.GetAddressBytes();
+                for (int i = 0; i < addressBytes.Length; i++)
+                {
+                    m_Buffer[8 + i] = addressBytes[i];
+                }
+            }
+            else
             {
                 // IPv4 Address serialization
                 m_Buffer[4] = unchecked((byte)(ipAddress.Address));
@@ -187,33 +187,30 @@ namespace System.Net
 
         internal IPAddress GetIPAddress()
         {
-            //if (Family == AddressFamily.InterNetworkV6)
-            //{
-            //    byte[] address = new byte[IPAddress.IPv6AddressBytes];
-            //    for (int i = 0; i < address.Length; i++)
-            //    {
-            //        address[i] = m_Buffer[i + 8];
-            //    }
-
-            //    long scope = (long)((m_Buffer[27] << 24) +
-            //                        (m_Buffer[26] << 16) +
-            //                        (m_Buffer[25] << 8) +
-            //                        (m_Buffer[24]));
-
-            //    return new IPAddress(address, scope);
-
-            //}
-            //else if (Family == AddressFamily.InterNetwork)
+            if (Family == AddressFamily.InterNetworkV6)
             {
-                long address = (
-                        (m_Buffer[4] & 0x000000FF) |
-                        (m_Buffer[5] << 8 & 0x0000FF00) |
-                        (m_Buffer[6] << 16 & 0x00FF0000) |
-                        (m_Buffer[7] << 24)
-                        ) & 0x00000000FFFFFFFF;
+                byte[] addr = new byte[IPAddress.IPv6AddressBytes];
+                for (int i = 0; i < addr.Length; i++)
+                {
+                    addr[i] = m_Buffer[i + 8];
+                }
 
-                return new IPAddress(address);
+                long scope = (long)((m_Buffer[27] << 24) +
+                                    (m_Buffer[26] << 16) +
+                                    (m_Buffer[25] << 8) +
+                                    (m_Buffer[24]));
+
+                return new IPAddress(addr, scope);
             }
+
+            long address = (
+                    (m_Buffer[4] & 0x000000FF) |
+                    (m_Buffer[5] << 8 & 0x0000FF00) |
+                    (m_Buffer[6] << 16 & 0x00FF0000) |
+                    (m_Buffer[7] << 24)
+                    ) & 0x00000000FFFFFFFF;
+
+            return new IPAddress(address);
         }
     }
 }

--- a/nanoFramework.System.Net/Sockets/NetworkStream.cs
+++ b/nanoFramework.System.Net/Sockets/NetworkStream.cs
@@ -124,7 +124,7 @@ namespace System.Net.Sockets
         /// <value>true if data can be read from the stream; otherwise, false. The default value is true.</value>
         /// <remarks>
         /// If CanRead is true, <see cref="NetworkStream"/> allows calls to the <see cref="Read"/> method. Provide the appropriate FileAccess enumerated value in the constructor to set 
-        /// the readability and writability of the <see cref="NetworkStream"/>. The CanRead property is set when the <see cref="NetworkStream"/> is initialized.
+        /// the readability and write-ability of the <see cref="NetworkStream"/>. The CanRead property is set when the <see cref="NetworkStream"/> is initialized.
         /// </remarks>
         public override bool CanRead { get { return true; } }
 

--- a/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/nanoFramework.System.Net/Sockets/Socket.cs
@@ -61,7 +61,7 @@ namespace System.Net.Sockets
         /// The addressFamily parameter specifies the addressing scheme that the <see cref="Socket"/> class uses, the socketType parameter specifies the type of the <see cref="Socket"/> class, 
         /// and the protocolType parameter specifies the protocol used by <see cref="Socket"/>. The three parameters are not independent. Some address families restrict which 
         /// protocols can be used with them, and often the <see cref="Socket"/> type is implicit in the protocol. If the combination of address family, <see cref="Socket"/> type, and protocol type
-        /// esults in an invalid Socket, this constructor throws a SocketException.
+        /// results in an invalid Socket, this constructor throws a SocketException.
         /// </remarks>
         public Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
@@ -1101,7 +1101,7 @@ namespace System.Net.Sockets
         }
 
         /// <summary>
-        /// Deconstructor
+        /// De constructor
         /// </summary>
         ~Socket()
         {

--- a/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/nanoFramework.System.Net/Sockets/Socket.cs
@@ -1100,9 +1100,6 @@ namespace System.Net.Sockets
             GC.SuppressFinalize(this);
         }
 
-        /// <summary>
-        /// De constructor
-        /// </summary>
         ~Socket()
         {
             Dispose(false);


### PR DESCRIPTION

## Description
This change goes with the interpreter update for IDF 5.1.1
It updates the socket code to support working with IPV6 for support of OpenThread and for general use.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Tested changes in IPAddress to support IPV6 format addresses for Parsing and Outputting addresses.
- Tested with some local UDP and TCPIP socket code


TODO 
- Add some test cases for IPV6


## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
