### PR TITLE
Added `==` and `!=` operator overloads to `IpAddress` 

### DIFF
--- a/Tests/IPAddressTests/IPAddressTests.cs
+++ b/Tests/IPAddressTests/IPAddressTests.cs
@@ -16,7 +16,7 @@ namespace NFUnitTestIPAddress
     public class IPAddressTests
     {
         [Setup]
-        public void SetupConnectToEthernetTests()
+        public void Setup()
         {
             // Comment next line to run the tests on a real hardware
             Assert.SkipTest("Skipping tests using nanoCLR Win32 in a pipeline");
@@ -300,6 +300,25 @@ namespace NFUnitTestIPAddress
                         + socketAddress1.ToString() + " " + socketAddress1.GetHashCode()
                         + " as " + socketAddress2.ToString() + " " + socketAddress2.GetHashCode());
             }
+        }
+
+        [TestMethod]
+        public void Equality_Tests()
+        {
+            var privateAddress = new IPAddress(new byte[] { 192, 168, 0, 1 });
+            var publicAddress = new IPAddress(new byte[] { 1, 1, 1, 1 });
+
+            // Equal
+            Assert.IsTrue(privateAddress.Equals(new IPAddress(new byte[]{192, 168, 0 , 1})), "192.168.0.1 equals 192.168.0.1");
+            Assert.IsTrue(publicAddress.Equals(new IPAddress(new byte[] { 1, 1, 1, 1 })), "1.1.1.1 equals 1.1.1.1");
+            Assert.IsTrue(privateAddress == new IPAddress(new byte[] { 192, 168, 0, 1 }), "192.168.0.1 == 192.168.0.1");
+            Assert.IsTrue(publicAddress == new IPAddress(new byte[] { 1, 1, 1, 1 }), "1.1.1.1 == 1.1.1.1");
+
+            // Not Equal
+            Assert.IsFalse(privateAddress.Equals(new IPAddress(new byte[] { 192, 168, 0, 2 })), "192.168.0.1 not equals 192.168.0.2");
+            Assert.IsFalse(publicAddress.Equals(new IPAddress(new byte[] { 1, 1, 1, 2 })), "1.1.1.1 not equals 1.1.1.2");
+            Assert.IsTrue(privateAddress != new IPAddress(new byte[] { 192, 168, 0, 2 }), "192.168.0.1 == 192.168.0.2");
+            Assert.IsTrue(publicAddress != new IPAddress(new byte[] { 1, 1, 1, 2 }), "1.1.1.1 == 1.1.1.2");
         }
     }
 }

--- a/Tests/IPAddressTests/IPAddressTests.cs
+++ b/Tests/IPAddressTests/IPAddressTests.cs
@@ -305,18 +305,18 @@ namespace NFUnitTestIPAddress
         [TestMethod]
         public void Equality_Tests()
         {
-            var privateAddress = new IPAddress(new byte[] { 192, 168, 0, 1 });
-            var publicAddress = new IPAddress(new byte[] { 1, 1, 1, 1 });
+            var privateAddress = IPAddress.Parse("192.168.0.1");
+            var publicAddress = IPAddress.Parse("1.1.1.1");
 
             // Equal
-            Assert.IsTrue(privateAddress.Equals(new IPAddress(new byte[]{192, 168, 0 , 1})), "192.168.0.1 equals 192.168.0.1");
-            Assert.IsTrue(publicAddress.Equals(new IPAddress(new byte[] { 1, 1, 1, 1 })), "1.1.1.1 equals 1.1.1.1");
+            Assert.AreEqual(privateAddress, IPAddress.Parse("192.168.0.1"));
+            Assert.AreEqual(publicAddress, IPAddress.Parse("1.1.1.1"));
             Assert.IsTrue(privateAddress == new IPAddress(new byte[] { 192, 168, 0, 1 }), "192.168.0.1 == 192.168.0.1");
             Assert.IsTrue(publicAddress == new IPAddress(new byte[] { 1, 1, 1, 1 }), "1.1.1.1 == 1.1.1.1");
 
             // Not Equal
-            Assert.IsFalse(privateAddress.Equals(new IPAddress(new byte[] { 192, 168, 0, 2 })), "192.168.0.1 not equals 192.168.0.2");
-            Assert.IsFalse(publicAddress.Equals(new IPAddress(new byte[] { 1, 1, 1, 2 })), "1.1.1.1 not equals 1.1.1.2");
+            Assert.AreNotEqual(privateAddress, IPAddress.Parse("1.1.1.1"));
+            Assert.AreNotEqual(publicAddress, IPAddress.Parse("192.168.0.1"));
             Assert.IsTrue(privateAddress != new IPAddress(new byte[] { 192, 168, 0, 2 }), "192.168.0.1 == 192.168.0.2");
             Assert.IsTrue(publicAddress != new IPAddress(new byte[] { 1, 1, 1, 2 }), "1.1.1.1 == 1.1.1.2");
         }

--- a/Tests/IPAddressTests/IPAddressTests.nfproj
+++ b/Tests/IPAddressTests/IPAddressTests.nfproj
@@ -61,6 +61,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\nanoFramework.System.Net\System.Net.nfproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.lock.json" />
+  </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <!-- MANUAL UPDATE HERE -->
   <ProjectExtensions>

--- a/Tests/IPAddressTests/nano.runsettings
+++ b/Tests/IPAddressTests/nano.runsettings
@@ -2,14 +2,16 @@
 <RunSettings>
    <!-- Configurations that affect the Test Framework -->
    <RunConfiguration>
-       <MaxCpuCount>1</MaxCpuCount>
        <ResultsDirectory>.\TestResults</ResultsDirectory><!-- Path relative to solution directory -->
        <TestSessionTimeout>120000</TestSessionTimeout><!-- Milliseconds -->
        <TargetFrameworkVersion>net48</TargetFrameworkVersion>
        <TargetPlatform>x64</TargetPlatform>
    </RunConfiguration>
    <nanoFrameworkAdapter>
-       <Logging>None</Logging>
-       <IsRealHardware>False</IsRealHardware>
+       <Logging>None</Logging> <!--Set to the desired level of logging for Unit Test execution. Possible values are: None, Detailed, Verbose, Error. -->
+       <IsRealHardware>False</IsRealHardware><!--Set to true to run tests on real hardware. -->
+       <RealHardwarePort>COM3</RealHardwarePort><!--Specify the COM port to use to connect to a nanoDevice. If none is specified, a device detection is performed and the 1st available one will be used. -->
+       <CLRVersion></CLRVersion><!--Specify the nanoCLR version to use. If not specified, the latest available will be used. -->
+       <PathToLocalCLRInstance></PathToLocalCLRInstance><!--Specify the path to a local nanoCLR instance. If not specified, the default one installed with nanoclr CLR witll be used. -->
    </nanoFrameworkAdapter>
 </RunSettings>

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -196,9 +196,9 @@ namespace System.Net
         }
 
         /// <summary>
-        /// Provides a copy of the <see cref="IPAddress"/> as an array of bytes.
+        /// Provides a copy of the <see cref="IPAddress"/> as an array of bytes in network order.
         /// </summary>
-        /// <returns>A Byte array.</returns>
+        /// <returns>A <see langword="byte"/> array.</returns>
         public byte[] GetAddressBytes()
         {
             return new[]

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -167,11 +167,10 @@ namespace System.Net
         /// <summary>
         /// Compares two IP addresses.
         /// </summary>
-        /// <param name="obj">An <see cref="IPAddress"/> instance to compare to the current instance.</param>
-        /// <returns></returns>
-        public override bool Equals(object obj)
+        /// <param name="comparand">An <see cref="IPAddress"/> instance to compare to the current instance.</param>
+        public override bool Equals(object comparand)
         {
-            return obj is IPAddress other && Equals(other);
+            return comparand is IPAddress other && Equals(other);
         }
 
         /// <summary>

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -66,11 +66,6 @@ namespace System.Net
         internal const int NumberOfLabels = IPv6AddressBytes / 2;
 
         /// <summary>
-        /// A lazily initialized cache of the <see cref="GetHashCode"/> value.
-        /// </summary>
-        private int _hashCode;
-
-        /// <summary>
         /// Gets the address family of the IP address.
         /// </summary>
         /// <value>Returns <see cref="AddressFamily.InterNetwork"/> for IPv4 or <see cref="AddressFamily.InterNetworkV6"/> for IPv6.</value>
@@ -271,21 +266,16 @@ namespace System.Net
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            if (_hashCode == 0)
+            // For IPv6 addresses, we cannot simply return the integer
+            // representation as the hashcode. Instead, we calculate
+            // the hashcode from the string representation of the address.
+            if (_family == AddressFamily.InterNetworkV6)
             {
-                // For IPv6 addresses, we cannot simply return the integer
-                // representation as the hashcode. Instead, we calculate
-                // the hashcode from the string representation of the address.
-                if (_family == AddressFamily.InterNetworkV6)
-                {
-                    _hashCode = ToString().GetHashCode();
-                }
-
-                // For IPv4 addresses, we can simply use the integer representation.
-                _hashCode = unchecked((int)Address);
+                return ToString().GetHashCode();
             }
 
-            return _hashCode;
+            // For IPv4 addresses, we can simply use the integer representation.
+            return unchecked((int)Address);
         }
 
         // For security, we need to be able to take an IPAddress and make a copy that's immutable and not derived.

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -168,6 +168,7 @@ namespace System.Net
         /// Compares two IP addresses.
         /// </summary>
         /// <param name="comparand">An <see cref="IPAddress"/> instance to compare to the current instance.</param>
+        /// <returns><see langword="true"/> if the two addresses are equal; otherwise, <see langword="false"/>.</returns>
         public override bool Equals(object comparand)
         {
             return comparand is IPAddress other && Equals(other);

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -4,7 +4,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System.Collections;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -158,7 +157,7 @@ namespace System.Net
         /// Tests whether two <see cref="IPAddress"/> objects are the same.
         /// </summary>
         public static bool operator ==(IPAddress left, IPAddress right) => left is not null && left.Equals(right);
-            
+
         /// <summary>
         /// Tests whether two <see cref='Rectangle'/> objects differ in location or size.
         /// </summary>

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -177,22 +177,22 @@ namespace System.Net
         /// <summary>
         /// Compares two IP addresses.
         /// </summary>
-        /// <param name="other">An <see cref="IPAddress"/> instance to compare to the current instance.</param>
-        /// <returns></returns>
-        public bool Equals(IPAddress other)
+        /// <param name="comparand">An <see cref="IPAddress"/> instance to compare to the current instance.</param>
+        /// <returns><see langword="true"/> if the two addresses are equal; otherwise, <see langword="false"/>.</returns>
+        public bool Equals(IPAddress comparand)
         {
-            if (other is null)
+            if (comparand is null)
             {
                 return false;
             }
 
             // Compare families before address representations
-            if (AddressFamily != other.AddressFamily)
+            if (AddressFamily != comparand.AddressFamily)
             {
                 return false;
             }
 
-            return Address == other.Address;
+            return Address == comparand.Address;
         }
 
         /// <summary>

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -154,14 +154,20 @@ namespace System.Net
         }
 
         /// <summary>
-        /// Tests whether two <see cref="IPAddress"/> objects are the same.
+        /// Indicates whether two <see cref="IPAddress"/> objects are equal.
         /// </summary>
-        public static bool operator ==(IPAddress left, IPAddress right) => left is not null && left.Equals(right);
+        /// <param name="a">The <see cref="IPAddress"/> to compare with <paramref name="b"/>.</param>
+        /// <param name="b">The <see cref="IPAddress"/> to compare with <paramref name="a"/>.</param>
+        /// <returns><see langword="true"/> if <paramref name="b"/> is equal to <paramref name="a"/>; otherwise, <see langword="false"/>.</returns>   
+        public static bool operator ==(IPAddress a, IPAddress b) => a is not null && a.Equals(b);
 
         /// <summary>
-        /// Tests whether two <see cref='Rectangle'/> objects differ in location or size.
+        /// Indicates whether two <see cref="IPAddress"/> objects are not equal.
         /// </summary>
-        public static bool operator !=(IPAddress left, IPAddress right) => !(left == right);
+        /// <param name="a">The <see cref="IPAddress"/> to compare with <paramref name="b"/>.</param>
+        /// <param name="b">The <see cref="IPAddress"/> to compare with <paramref name="a"/>.</param>
+        /// <returns><see langword="true"/> if <paramref name="b"/> is not equal to <paramref name="a"/>; otherwise, <see langword="false"/>.</returns>   
+        public static bool operator !=(IPAddress a, IPAddress b) => !(a == b);
 
         /// <summary>
         /// Compares two IP addresses.

--- a/nanoFramework.System.Net/NetworkInformation/NetworkInterface.cs
+++ b/nanoFramework.System.Net/NetworkInformation/NetworkInterface.cs
@@ -470,10 +470,10 @@ namespace System.Net.NetworkInformation
         #region native methods
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int GetNetworkInterfaceCount();
+        private extern static int GetNetworkInterfaceCount();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern NetworkInterface GetNetworkInterface(uint interfaceIndex);
+        private extern static NetworkInterface GetNetworkInterface(uint interfaceIndex);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern void InitializeNetworkInterfaceSettings();

--- a/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.5.0")]
+[assembly: AssemblyNativeVersion("100.1.5.1")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.2.0.0")]
+[assembly: AssemblyNativeVersion("100.2.0.1")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Added `==` and `!=` operator overloads

## Motivation and Context
There is existing code that does not use the Equals method so this will fix that.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
On device

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [X] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
