### PR TITLE
Fixing null checks in equality operators

### DIFF
--- a/Tests/IPAddressTests/IPAddressTests.cs
+++ b/Tests/IPAddressTests/IPAddressTests.cs
@@ -19,7 +19,7 @@ namespace NFUnitTestIPAddress
         public void Setup()
         {
             // Comment next line to run the tests on a real hardware
-            Assert.SkipTest("Skipping tests using nanoCLR Win32 in a pipeline");
+            //Assert.SkipTest("Skipping tests using nanoCLR Win32 in a pipeline");
         }
 
         [TestMethod]
@@ -307,18 +307,26 @@ namespace NFUnitTestIPAddress
         {
             var privateAddress = IPAddress.Parse("192.168.0.1");
             var publicAddress = IPAddress.Parse("1.1.1.1");
+            IPAddress defaultAddress = default;
+            IPAddress nullAddress = null;
+
+            // Is
+            Assert.IsTrue(nullAddress is null, "nullAddress is null");
 
             // Equal
             Assert.AreEqual(privateAddress, IPAddress.Parse("192.168.0.1"));
             Assert.AreEqual(publicAddress, IPAddress.Parse("1.1.1.1"));
             Assert.IsTrue(privateAddress == new IPAddress(new byte[] { 192, 168, 0, 1 }), "192.168.0.1 == 192.168.0.1");
             Assert.IsTrue(publicAddress == new IPAddress(new byte[] { 1, 1, 1, 1 }), "1.1.1.1 == 1.1.1.1");
+            Assert.IsTrue(defaultAddress == default, "default == default");
+            Assert.IsTrue(nullAddress == null, "nullAddress == null");
 
             // Not Equal
             Assert.AreNotEqual(privateAddress, IPAddress.Parse("1.1.1.1"));
             Assert.AreNotEqual(publicAddress, IPAddress.Parse("192.168.0.1"));
             Assert.IsTrue(privateAddress != new IPAddress(new byte[] { 192, 168, 0, 2 }), "192.168.0.1 == 192.168.0.2");
             Assert.IsTrue(publicAddress != new IPAddress(new byte[] { 1, 1, 1, 2 }), "1.1.1.1 == 1.1.1.2");
+            Assert.IsTrue((IPAddress) null != privateAddress, "(IPAddress) null != privateAddress");
         }
     }
 }

--- a/Tests/IPAddressTests/IPAddressTests.cs
+++ b/Tests/IPAddressTests/IPAddressTests.cs
@@ -19,7 +19,7 @@ namespace NFUnitTestIPAddress
         public void Setup()
         {
             // Comment next line to run the tests on a real hardware
-            //Assert.SkipTest("Skipping tests using nanoCLR Win32 in a pipeline");
+            Assert.SkipTest("Skipping tests using nanoCLR Win32 in a pipeline");
         }
 
         [TestMethod]

--- a/nanoFramework.System.Net/IPAddress.cs
+++ b/nanoFramework.System.Net/IPAddress.cs
@@ -168,7 +168,15 @@ namespace System.Net
         /// <param name="a">The <see cref="IPAddress"/> to compare with <paramref name="b"/>.</param>
         /// <param name="b">The <see cref="IPAddress"/> to compare with <paramref name="a"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="b"/> is equal to <paramref name="a"/>; otherwise, <see langword="false"/>.</returns>   
-        public static bool operator ==(IPAddress a, IPAddress b) => a is not null && a.Equals(b);
+        public static bool operator ==(IPAddress a, IPAddress b)
+        {
+            if (a is null && b is null)
+            {
+                return true;
+            }
+
+            return a is not null && a.Equals(b);
+        }
 
         /// <summary>
         /// Indicates whether two <see cref="IPAddress"/> objects are not equal.


### PR DESCRIPTION
## Description
- Added a check that left and right are both null
- Added unit tests to validate equality checking of null

## Motivation and Context
It was broken: https://github.com/nanoframework/System.Net/pull/310#issuecomment-1913534827

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Unit tests

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [X] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [X] I have added new tests to cover my changes.
