### PR TITLE
Fix check for max values inclusive for ssid and password

### DIFF
--- a/nanoFramework.System.Net/NetworkInformation/Wireless80211Configuration.cs
+++ b/nanoFramework.System.Net/NetworkInformation/Wireless80211Configuration.cs
@@ -116,8 +116,8 @@ namespace System.Net.NetworkInformation
             }
 
             // check password and SSID length
-            if ((_password.Length    >= MaxPasswordLength) || 
-                (_ssid.Length        >= MaxSsidLength))
+            if ((_password.Length    > MaxPasswordLength) || 
+                (_ssid.Length        > MaxSsidLength))
             {
 #pragma warning disable S3928 // OK to not include a meaningful message
                 throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description

Validation of the wireless configuration fails if either the SSID is 32 characters long or the password is 64 characters long. By definition, however, these may have these respective lengths.

**changes:**
- Throwing `ArgumentOutOfRangeException` only when the `SSID` length is greater than 32 characters.
- throwing `ArgumentOutOfRangeException` only when the `PASSWORD` is greater than 64 characters.

**Backed up on the native side here:**

https://github.com/nanoframework/nf-interpreter/blob/main/src/HAL/Include/nanoHAL_Network.h#L268

**and here:**

https://github.com/nanoframework/nf-interpreter/blob/main/src/HAL/Include/nanoHAL_Network.h#L271

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->

I did not raise an issue.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**See the discussion:**

https://github.com/orgs/nanoframework/discussions/1594#discussioncomment-11946872

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
