### PR TITLE
Remove unused code in `Socket`

### DIFF
--- a/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/nanoFramework.System.Net/Sockets/Socket.cs
@@ -36,17 +36,6 @@ namespace System.Net.Sockets
         [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
         private SocketType _socketType = SocketType.Unknown;
 
-        // Our internal state doesn't automatically get updated after a non-blocking connect
-        // completes.  Keep track of whether we're doing a non-blocking connect, and make sure
-        // to poll for the real state until we're done connecting.
-        [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
-        private bool _nonBlockingConnectInProgress;
-
-        // Keep track of the kind of endpoint used to do a non-blocking connect, so we can set
-        // it to m_RightEndPoint when we discover we're connected.
-        [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
-        private EndPoint _nonBlockingConnectRightEndPoint;
-
         // _rightEndPoint is null if the socket has not been bound. Otherwise, it is any EndPoint of the correct type (IPEndPoint, etc).
         [Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
         internal EndPoint _rightEndPoint;
@@ -343,18 +332,6 @@ namespace System.Net.Sockets
 
             EndPoint endPointSnapshot = remoteEP;
             Snapshot(ref endPointSnapshot);
-
-            if (m_fBlocking)
-            {
-                // blocking connect
-                _nonBlockingConnectInProgress = false;
-            }
-            else
-            {
-                // non blocking connect
-                _nonBlockingConnectInProgress = true;
-                _nonBlockingConnectRightEndPoint = endPointSnapshot;
-            }
 
             NativeSocket.connect(this, endPointSnapshot, !m_fBlocking);
 


### PR DESCRIPTION
## Description
- Remove unused code in Socket.

## Motivation and Context
- We don't have support for non-blocking connections, so this code wasn't doing anything useful.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
