### PR TITLE
Add `Connect` to `Socket`

### DIFF
--- a/nanoFramework.System.Net/Properties/AssemblyInfo.cs
+++ b/nanoFramework.System.Net/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.2.0.11")]
+[assembly: AssemblyNativeVersion("100.2.0.12")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/nanoFramework.System.Net/Sockets/Socket.cs
+++ b/nanoFramework.System.Net/Sockets/Socket.cs
@@ -181,6 +181,14 @@ namespace System.Net.Sockets
         }
 
         /// <summary>
+        /// Gets a value that indicates whether a <see cref="Socket"/> is connected to a remote host as of the last <see cref="Send"/> or <see cref="Receive"/> operation.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the <see cref="Socket"/> was connected to a remote resource as of the most recent operation; otherwise, <see langword="false"/>.
+        /// </value>
+        public bool Connected => _rightEndPoint != null && m_Handle != -1;
+
+        /// <summary>
         /// Gets or sets a value that specifies the amount of time after which a synchronous <see cref="Receive(Byte[])"/> call will time out.
         /// </summary>
         /// <value>


### PR DESCRIPTION
## Description
- Bump native assembly version.

## Motivation and Context
- Provide a way for users to check connection status of the `Socket`.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
